### PR TITLE
SCR-06: Improve Seeds Performance [Draft]

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,10 +12,34 @@
 
 IO.puts("Starting to run seeds file...")
 
-alias Score.Entities.Users
+alias Score.Entities.Schemas.User
+alias Score.Repo
 
-(1..10_000)
-|> Stream.each(fn _ -> Users.create(%{points: 0}) end)
-|> Stream.run()
+stream =
+  Stream.map(1..1_000_000, fn _ ->
+    # Repo.insert_all() don't insert automatically inserted_at and updated_at
+    date_time =
+      NaiveDateTime.truncate(
+        NaiveDateTime.utc_now(),
+        :second
+      )
+
+    %{points: 0, inserted_at: date_time, updated_at: date_time}
+  end)
+
+Repo.transaction(fn ->
+  stream
+  |> Stream.chunk_every(15_000)
+  |> Task.async_stream(
+    fn batch ->
+      {batches_cursor, _} = Repo.insert_all(User, batch)
+      batches_cursor
+    end,
+    ordered: false
+  )
+  |> Enum.reduce(0, fn {:ok, batches_cursor}, accumulator ->
+    batches_cursor + accumulator
+  end)
+end)
 
 IO.puts("Successfully runned seeds!...")


### PR DESCRIPTION
## Proposal

### Card: [SCR-06: Improve Seeds Performance](https://github.com/JulianaHelena5/score/issues/9)

## Context
The main goal of your pull request.

This PR aims to have a [`seeds.exs`](https://hexdocs.pm/phoenix/1.3.0-rc.0/seeding_data.html) file to seed my Database with some initial data (actually, with a large amount of data :) ) using a better approach that takes a maximum of 30 seconds to run - fixing the bug \o/ 

## Dependencies
none.

## Solution description
To solve it I used [Streams](https://hexdocs.pm/elixir/1.12/Stream.html), [chunking](https://hexdocs.pm/elixir/1.12/Stream.html#chunk_every/2) the Stream data inside a Transaction and then using [Task.async_stream](https://hexdocs.pm/elixir/1.12/Task.html#async_stream/3) to [insert_all](https://hexdocs.pm/ecto/Ecto.Repo.html#c:insert_all/3) of them.

I'm documenting the role process of technical decision ( With all [Elixir Forum](https://elixirforum.com/) posts that I read and the really good chapter of [Programming Ecto](https://pragprog.com/titles/wmecto/programming-ecto/) book) and I'll add it at the card #5 but feel free to ask me about it :)

## Definitions of Done:
- [x] All tests were performed successfully locally
- [x] My changes generate no new warnings
- [ ] I have added tests that related with my fix or my feature
- [ ] Extended the README / Documentation, if necessary
- [x] My branch is updated with main
